### PR TITLE
Added breakpoint support to Odin files

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
 				"language": "odin",
 				"path": "./snippets/snippets.json"
 			}
-		]
+		],
+		"breakpoints": [{ "language": "odin" }]
 	},
 	"__metadata": {
 		"id": "f3a333b3-12da-445d-b048-82a3b8f47a7c",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,24 @@
 				"path": "./snippets/snippets.json"
 			}
 		],
-		"breakpoints": [{ "language": "odin" }]
+		"breakpoints": [{ "language": "odin" }],
+		"problemMatchers": [
+            {
+                "name": "odin",
+                "owner": "odin",
+                "fileLocation": [
+                    "absolute"
+                ],
+                "pattern": {
+                    "regexp": "^(.*)\\((\\d+):(\\d+)\\)\\s+(Warning|Error|Syntax Error):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            }
+        ]
 	},
 	"__metadata": {
 		"id": "f3a333b3-12da-445d-b048-82a3b8f47a7c",

--- a/package.json
+++ b/package.json
@@ -51,12 +51,11 @@
                     "absolute"
                 ],
                 "pattern": {
-                    "regexp": "^(.*)\\((\\d+):(\\d+)\\)\\s+(Warning|Error|Syntax Error):\\s+(.*)$",
+                    "regexp": "^(.*)\\((\\d+):(\\d+)\\)\\s+(.*)$",
                     "file": 1,
                     "line": 2,
                     "column": 3,
-                    "severity": 4,
-                    "message": 5
+                    "message": 4
                 }
             }
         ]


### PR DESCRIPTION
It is possible (and great) to debug Odin programs using the cpp extension for Visual Studio Code if the appropriate tasks and launch jsons are created. However, to be able to set breakpoints in odin files, the user needs to select File->Preference->Settings -> debug.allowBreakpointsEverywhere . 

This is inconvenient, and easily solvable by having this extension declaring that VS Code should accept breakpoints in odin files.

After this minimal change, VSCode accepts breakpoints in odin files without the user having to enable that setting.