### PR TITLE
add identifiers to recognised syntax patterns

### DIFF
--- a/syntaxes/odin.tmLanguage.json
+++ b/syntaxes/odin.tmLanguage.json
@@ -22,11 +22,15 @@
 		},
 		{
 			"include": "#punctuation"
+		},
+		{
+			"include": "#identifier"
 		}
 	],
 	"repository": {
 		"identifier": {
 			"patterns": [{
+				"name": "variable.other.odin",
 				"match": "\\b[[:alpha:]_][[:alnum:]_]*\\b"
 			}]
 		},


### PR DESCRIPTION
Themes will not color a lot of the code (leave it at the default color value) otherwise. With the lowest priority this should only affect variable names. 